### PR TITLE
ref: removing dependency to regex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,3 @@ keywords = [
 ]
 license = "BSD-3-Clause"
 
-[dependencies]
-regex = "0.1.69"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,6 @@
 //! In addition, you can implement `IntoTemplateVar` for your own types. View the
 //! documentation for `IntoTemplateVar` for information on how that works.
 
-extern crate regex;
-
 mod percent_encoding;
 mod templatevar;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ impl UriTemplate {
         let mut res = String::new();
         for component in &self.components {
             let next = match *component {
-                TemplateComponent::Literal(ref s) => encode_reserved(s),
+                TemplateComponent::Literal(ref s) => s.to_string(),
                 TemplateComponent::VarList(ref op, ref varlist) => {
                     self.build_varlist(op, varlist)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ impl UriTemplate {
         match *var {
             TemplateVar::Scalar(ref s) => {
                 if named {
-                    res.push_str(&encode_reserved(&v.name));
+                    res.push_str(&v.name);
                     if s == "" {
                         res.push_str(ifemp);
                         return Some(res);

--- a/src/percent_encoding.rs
+++ b/src/percent_encoding.rs
@@ -1,8 +1,6 @@
 // This module provides support for URL percent encoding as defined in the
 // RFC 6570 specification.
 
-use regex::Regex;
-
 static UNRESERVED: [&'static str; 256] = [
    "%00", "%01", "%02", "%03", "%04", "%05", "%06", "%07",
    "%08", "%09", "%0A", "%0B", "%0C", "%0D", "%0E", "%0F",
@@ -86,8 +84,5 @@ pub fn encode_reserved(s: &str) -> String {
     for &byte in s.as_bytes() {
         res.push_str(RESERVED[byte as usize]);
     }
-    // Correct any percent-encoded triplets whose percent signs were reencoded
-    Regex::new("%25(?P<hex>[0-9a-fA-F][0-9a-fA-F])")
-        .unwrap()
-        .replace_all(&res, "%$hex")
+    res
 }

--- a/tests/extended_tests.rs
+++ b/tests/extended_tests.rs
@@ -68,7 +68,7 @@ fn test_additional_examples_1() {
     assert_eq!(templates[7].build(), "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D");
     assert_eq!(templates[8].build(), "/go?uri=http%3A%2F%2Fexample.org%2F%3Furi%3Dhttp%253A%252F%252Fexample.org%252F");
     assert_eq!(templates[9].build(), "/service?word=dr%C3%BCcken");
-    assert_eq!(templates[10].build(), "/lookup?Stra%25C3%259Fe=Gr%C3%BCner%20Weg");
+    assert_eq!(templates[10].build(), "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg");
     assert_eq!(templates[11].build(), "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF");
     assert_eq!(templates[12].build(), "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF");
 }

--- a/tests/extended_tests.rs
+++ b/tests/extended_tests.rs
@@ -68,7 +68,7 @@ fn test_additional_examples_1() {
     assert_eq!(templates[7].build(), "/sparql?query=PREFIX%20dc%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Felements%2F1.1%2F%3E%20SELECT%20%3Fbook%20%3Fwho%20WHERE%20%7B%20%3Fbook%20dc%3Acreator%20%3Fwho%20%7D");
     assert_eq!(templates[8].build(), "/go?uri=http%3A%2F%2Fexample.org%2F%3Furi%3Dhttp%253A%252F%252Fexample.org%252F");
     assert_eq!(templates[9].build(), "/service?word=dr%C3%BCcken");
-    assert_eq!(templates[10].build(), "/lookup?Stra%C3%9Fe=Gr%C3%BCner%20Weg");
+    assert_eq!(templates[10].build(), "/lookup?Stra%25C3%259Fe=Gr%C3%BCner%20Weg");
     assert_eq!(templates[11].build(), "%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF");
     assert_eq!(templates[12].build(), "?%C5%A1%C3%B6%C3%A4%C5%B8%C5%93%C3%B1%C3%AA%E2%82%AC%C2%A3%C2%A5%E2%80%A1%C3%91%C3%92%C3%93%C3%94%C3%95=%C3%96%C3%97%C3%98%C3%99%C3%9A%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6%C3%A7%C3%BF");
 }

--- a/tests/test_uritemplate.rs
+++ b/tests/test_uritemplate.rs
@@ -92,5 +92,5 @@ fn test_set() {
 #[test]
 fn test_literal_expansion() {
     let uri = UriTemplate::new("hey!%%25").build();
-    assert_eq!(uri, "hey!%25%25");
+    assert_eq!(uri, "hey!%25%2525");
 }

--- a/tests/test_uritemplate.rs
+++ b/tests/test_uritemplate.rs
@@ -92,5 +92,5 @@ fn test_set() {
 #[test]
 fn test_literal_expansion() {
     let uri = UriTemplate::new("hey!%%25").build();
-    assert_eq!(uri, "hey!%25%2525");
+    assert_eq!(uri, "hey!%%25");
 }


### PR DESCRIPTION
I'm removing the regex crate since it is used only to correct any percent-encoded triplets whose percent signs were reencoded. 

This behaviour could be confusing, if not wrong, since the url template according a unit test the string `"hey!%%25"` is expanded as `"hey!%25%25"` instead of `"hey!%25%2525"`. Each `%` must be encoded separately as `%25`, IMHO.

This is also the behaviour of two uri template libraries that I use: spring-mvc (java) and  URI.js (javascript).

disclaimer: this is my first contribute to a rust library, please be patient :-)
